### PR TITLE
Responsive button for mobile layout added

### DIFF
--- a/bwmon/www/bwmon.css
+++ b/bwmon/www/bwmon.css
@@ -101,3 +101,21 @@
 	transform: rotate(-90deg);
 
 }
+
+/* Button group responsive for mobile layout */
+@media (max-width: 768px) {
+  .btn-responsive {
+    padding:2px 4px;
+    font-size:80%;
+    line-height: 1;
+    border-radius:3px;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 992px) {
+  .btn-responsive {
+    padding:4px 9px;
+    font-size:90%;
+    line-height: 1.2;
+  }
+}

--- a/bwmon/www/bwmon.html
+++ b/bwmon/www/bwmon.html
@@ -129,27 +129,27 @@
 				<div class="left">
 					<div class="controls">
 						<div class="btn-group">
-							<label class="btn btn-default" ng-model="displayDensity" btn-radio="'Normal'">Normal</label>
-							<label class="btn btn-default" ng-model="displayDensity" btn-radio="'Compact'">Compact</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayDensity" btn-radio="'Normal'">Normal</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayDensity" btn-radio="'Compact'">Compact</label>
 						</div>
 					</div>
 					<div class="controls">
 						<div class="btn-group" tooltip="Shortcut double click on the device field in the table above to cycle through." tooltip-placement="right">
-							<label class="btn btn-default" ng-model="displayNameType" btn-radio="'NAME'">Name</label>
-							<label class="btn btn-default" ng-model="displayNameType" btn-radio="'IP'">IP</label>
-							<label class="btn btn-default" ng-model="displayNameType" btn-radio="'MAC'">MAC</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayNameType" btn-radio="'NAME'">Name</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayNameType" btn-radio="'IP'">IP</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayNameType" btn-radio="'MAC'">MAC</label>
 						</div>
 					</div>
 					<div class="controls">
 						<div class="btn-group">
-							<label class="btn btn-default" ng-model="displayRate" btn-radio="'Kbps'">Kbps</label>
-							<label class="btn btn-default" ng-model="displayRate" btn-radio="'KB/s'">KB/s</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayRate" btn-radio="'Kbps'">Kbps</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayRate" btn-radio="'KB/s'">KB/s</label>
 						</div>
 					</div>
 					<div class="controls">
 						<div class="btn-group">
-							<label class="btn btn-default" checked ng-model="displayStyleSheet" btn-radio="'bwmon'">Light</label>
-							<label class="btn btn-default" ng-model="displayStyleSheet" btn-radio="'bwmondark'">Dark</label>
+							<label class="btn btn-default btn-responsive" checked ng-model="displayStyleSheet" btn-radio="'bwmon'">Light</label>
+							<label class="btn btn-default btn-responsive" ng-model="displayStyleSheet" btn-radio="'bwmondark'">Dark</label>
 						</div>
 					</div>
 				</div>

--- a/bwmon/www/bwmondark.css
+++ b/bwmon/www/bwmondark.css
@@ -130,3 +130,21 @@
 .table>tbody>tr>td, .table>tbody>tr>th {
 	border-color: #191a21;
 }
+
+/* Button group responsive for mobile layout */
+@media (max-width: 768px) {
+  .btn-responsive {
+    padding:2px 4px;
+    font-size:80%;
+    line-height: 1;
+    border-radius:3px;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 992px) {
+  .btn-responsive {
+    padding:4px 9px;
+    font-size:90%;
+    line-height: 1.2;
+  }
+}


### PR DESCRIPTION
As @vortex-5 wrote in #48 the layout for mobiles isn't perfect. 
I added a new responsive class which scales the buttons.

#### bwmon.css/bwmondark.css
* responsive class for buttons. 
 _I don't like adding it twice but we don't have a css that gets loaded by both themes (except bootstrap), so I added it twice for now_
 
#### bwmon.html
 * added new class to html

![iPhone5ChromeInspector](https://cloud.githubusercontent.com/assets/13681191/24250845/8a7d49b0-0fd8-11e7-9df6-d7bd392b1ea6.jpg)
